### PR TITLE
ニコニコ動画の動画ID（例： sm9）での再生に対応

### DIFF
--- a/python/smile_music.py
+++ b/python/smile_music.py
@@ -710,6 +710,9 @@ async def play(ctx, args, add_infos={}):
 
     keyword = ' '.join(args[1:])
 
+    if niconico_id_pattern.match(args[1]):
+        args[1] = f"https://www.nicovideo.jp/watch/{args[1]}"
+
     result = niconico_pattern.subn('https://www.nicovideo.jp', args[1])
     args[1] = result[0]
     result = niconico_ms_pattern.subn('https://www.nicovideo.jp/watch',
@@ -1088,6 +1091,7 @@ ssl._create_default_https_context = ssl._create_unverified_context
 # conn = psycopg2.connect(host=os.environ.get('POSTGRES_HOST'), user=os.environ.get('POSTGRES_USER'), password=os.environ.get('POSTGRES_PASSWORD'), database=os.environ.get('POSTGRES_DB'), port=int(os.environ.get('POSTGRES_PORT')))
 niconico_pattern = re.compile(r'https://(www.nicovideo.jp|sp.nicovideo.jp)')
 niconico_ms_pattern = re.compile(r'https://nico.ms')
+niconico_id_pattern = re.compile(r'^[a-z]{2}[0-9]+$')
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-b',


### PR DESCRIPTION
`?p sm9` で陰陽師が流れるようにしました。

正規表現は今の時代 `^(sm|nm|so)[0-9]+$` くらいでも十分な気がしますが、[初期はこれ以外のprefixもあったらしい](https://dic.nicovideo.jp/a/id)ので、ひとまずこのような形にしています。

「動画IDの正規表現にマッチする文字列でのキーワード検索」ができなくなっている点は互換性がないので、丁寧にやるなら以下のいずれかをやったほうが良いかも、と思っています。

1. （強制的に）キーワード検索モードにするオプションを追加する  
例えば `?p sm9` なら陰陽師、 `?p -k sm9` なら sm9 でキーワード検索する
2. 逆に今回の追加機能をオプションにする  
例えば `?p sm9` なら sm9 でキーワード検索、 `?p -i sm9` なら陰陽師  
（でも `?p sm9` で陰陽師が流したい……）